### PR TITLE
Update a Dart Sass Host to version 1.0.1

### DIFF
--- a/src/SassWatcherTool.Tool/SassWatcherTool.Tool.csproj
+++ b/src/SassWatcherTool.Tool/SassWatcherTool.Tool.csproj
@@ -27,9 +27,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DartSassHost" Version="1.0.0-preview7" />
-		<PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.17.1" />
-		<PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.2.1" />
+		<PackageReference Include="DartSassHost" Version="1.0.1" />
+		<PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.20.8" />
+		<PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.3.6" />
 		<PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta2.21617.1" />


### PR DESCRIPTION
Hello, Magnus!

Dart Sass Host library has recently become stable, so I recommend that you update it, as well as its dependencies, to the latest versions.